### PR TITLE
Update `UserGuide.md`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -120,13 +120,13 @@ In the above example, we are deleting module CS2103T from Plannit.
 You may add a task using the `add task` command.
 
 This command will require two flags:
-* `m/`: This flag is to be followed immediately by the module code of the
+* `m/`: To be followed by the module code of the
   module which the task is associated with.
-* `d/`: This flag is to be followed immediately by the task description.
+* `d/`: To be followed by the task description.
 
 Format: `add task m/MODULE_CODE d/TASK_DESCRIPTION`
 * Each task **must** belong to a specific module.
-* The given module code should be that of an existing module in Plannit.
+* You should provide a module code of an existing module in Plannit.
 
 Example:
 ```
@@ -140,13 +140,14 @@ You may delete a task belonging to a particular module using the `delete
 task` command.
 
 This command will require two flags:
-* `m/`: This flag is to be followed immediately by the module code of the
-  module which assigned the task.
-* `n/`: This flag is to be followed immediately by the task number in the module.
+* `m/`: To be followed by the module code of the module which assigned the 
+  task.
+* `n/`: To be followed by the task number in the module.
 
 Format: `delete task m/MODULE_CODE n/TASK_NUMBER`
-* The given module code should be that of an existing module in Plannit.
-* The given task number has to be that of an existing task in the module.
+* You should provide a module code of an existing module in Plannit.
+* You should provide a task number corresponding to that of an existing task in 
+  the module.
 
 Example:
 ```
@@ -165,9 +166,9 @@ with the module code `CS2103T`.
 You may add a link to a specific module using the `add link` command.
 
 This command will require two flags:
-* `m/`: This flag is to be followed immediately by the module code of the
+* `m/`: To be followed by the module code of the
   module which is associated with the link.
-* `l/`: This flag is to be followed immediately by the link URL.
+* `l/`: To be followed by the link URL.
 
 Format: `add link m/MODULE_CODE l/LINK_URL`
 * When adding a link URL to a non-existent module code, Plannit shows an error message.
@@ -184,9 +185,9 @@ to the module with module code `CS2040C`.
 You may delete a link from a specific module using the `delete link` command.
 
 This command will require two flags:
-* `m/`: This flag is to be followed immediately by the module code of the
+* `m/`: To be followed by the module code of the
   module which is associated with the link.
-* `l/`: This flag is to be followed immediately by the link URL.
+* `l/`: To be followed by the link URL.
 
 Format: `delete link m/MODULE_CODE l/LINK_URL`
 * When deleting a link URL from a non-existent module code, Plannit shows an error message.


### PR DESCRIPTION
Changes:
1. Some sections described the flags as "`This flag is to be immediately followed by...`" while others used the phrase "`To be followed by...`". For consistency, all sections have been changed to "`To be followed by...`".
2. Guidelines under the format for `add task` and `delete task` are currently not in second-person tone. This may come across as unwelcoming to users. The guidelines has been rephrased to second-person.