### PR TITLE
Update user guide to directly address user (contacts)

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -210,10 +210,10 @@ This command will require two flags, and one optional flag:
 * `e/`: To be followed by the email of the new contact.
 * `p/`: (Optional flag) To be followed by the phone number of the new contact.
 
-Format: `add contact n/NAME e/EMAIL p/PHONE_NUMBER`
+Format: `add contact n/NAME e/EMAIL [p/PHONE_NUMBER]`
 * You cannot add a duplicate name into Plannit.
-* You may specify a phone number.
-* You cannot specify country code for phone number.
+* You may optionally specify a phone number.
+* You cannot specify any country code for phone number.
 * You cannot specify a non-8-digit phone number.
 
 Examples:  

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -208,10 +208,10 @@ This command will require two flags, and one optional flag:
 * `p/`: (Optional flag) To be followed by the phone number of the new contact.
 
 Format: `add contact n/NAME e/EMAIL p/PHONE_NUMBER`
-- You cannot add a duplicate name into Plannit.
-- You may specify a phone number.
-- You cannot specify country code for phone number.
-- You cannot specify a non-8-digit phone number.
+* You cannot add a duplicate name into Plannit.
+* You may specify a phone number.
+* You cannot specify country code for phone number.
+* You cannot specify a non-8-digit phone number.
 
 Examples:  
 ```
@@ -231,7 +231,7 @@ This command will require one flag:
 * `n/`: To be followed by the to-be-deleted contact name.
 
 Format: `delete contact n/NAME`
-- You cannot delete a non-existent contact.
+* You cannot delete a non-existent contact.
 
 Example:  
 ```

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -172,8 +172,9 @@ This command will require two flags, and one optional flag:
 
 Format: `add contact n/NAME e/EMAIL p/PHONE_NUMBER`
 - Specifying a phone number is optional.
-- When adding a duplicate name, Plannit will display an error message.
-- Phone numbers are compulsory to be exactly 8 digits and without country code.
+- You cannot add a duplicate name into Plannit.
+- You cannot specify country code for phone number.
+- You cannot specify a non-8-digit phone number.
 
 Examples:  
 ```
@@ -194,7 +195,7 @@ This command will require one flag:
 - `n/`: To be followed by the to-be-deleted contact name.
 
 Format: `delete contact n/NAME`
-- If the provided `NAME` does not exist in Plannit, Plannit shows an error message.
+- You cannot delete a non-existent contact.
 
 Example:  
 ```


### PR DESCRIPTION
Currently, the user guide addresses the user formally (eg "The user should...").

This needs to be changed as the user should feel personally included for a greater sense of belonging (eg "You should...").

Thus, this pull request aims to address the user directly by "You".