### PR TITLE
Create a `getModuleFromModuleCode` method to retrieve modules 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddTaskCommand.java
@@ -9,12 +9,14 @@ import java.util.List;
 import java.util.Set;
 
 import javafx.collections.ObservableList;
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.link.Link;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleTitle;
+import seedu.address.model.module.exceptions.ModuleNotFoundException;
 import seedu.address.model.module.task.Task;
 import seedu.address.model.module.task.TaskList;
 
@@ -39,8 +41,6 @@ public class AddTaskCommand extends Command {
             "New task added to: %1$s";
     public static final String MESSAGE_DUPLICATE_TASK =
             "This task already exists in this module.";
-    public static final String MESSAGE_MODULE_CODE_DOES_NOT_EXIST =
-            "The given module code does not exist!";
 
     private final AddTaskToModuleDescriptor addTaskToModuleDescriptor;
 
@@ -57,16 +57,16 @@ public class AddTaskCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Module> lastShownList = model.getFilteredModuleList();
+        ModuleCode moduleCodeOfModuleToAddTaskTo =
+                addTaskToModuleDescriptor.moduleCode;
         Module moduleToAddTaskTo = null;
-        // Search for module with matching module code.
-        for (Module module : lastShownList) {
-            if (module.getModuleCode().equals(addTaskToModuleDescriptor.moduleCode)) {
-                moduleToAddTaskTo = module;
-            }
+        try {
+            moduleToAddTaskTo =
+                    model.getModuleUsingModuleCode(moduleCodeOfModuleToAddTaskTo, true);
+        } catch (ModuleNotFoundException e) {
+            throw new CommandException(Messages.MESSAGE_NO_SUCH_MODULE);
         }
-        if (moduleToAddTaskTo == null) {
-            throw new CommandException(MESSAGE_MODULE_CODE_DOES_NOT_EXIST);
-        }
+        assert moduleToAddTaskTo != null;
         Module moduleWithNewTask = createModuleWithNewTask(moduleToAddTaskTo, addTaskToModuleDescriptor);
 
         Boolean taskWasAdded = !moduleToAddTaskTo.equals(moduleWithNewTask);

--- a/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteModuleCommand.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.exceptions.ModuleNotFoundException;
 
 /**
  * Deletes a module identified using the module code from Plannit.
@@ -35,21 +36,15 @@ public class DeleteModuleCommand extends Command {
         requireNonNull(model);
         ObservableList<Module> lastShownList = model.getFilteredModuleList();
 
-        boolean isFound = false;
         Module moduleToDelete = null;
-        for (Module module : lastShownList) {
-            if (module.isSameModule(new Module(targetModuleCode))) {
-                model.deleteModule(module);
-                moduleToDelete = module;
-                isFound = true;
-                break;
-            }
-        }
-
-        if (!isFound) {
+        try {
+            moduleToDelete =
+                    model.getModuleUsingModuleCode(targetModuleCode, true);
+        } catch (ModuleNotFoundException e) {
             throw new CommandException(Messages.MESSAGE_NO_SUCH_MODULE);
         }
-
+        assert moduleToDelete != null;
+        model.deleteModule(moduleToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_MODULE_SUCCESS, moduleToDelete));
     }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Set;
 
 import javafx.collections.ObservableList;
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
@@ -16,6 +17,7 @@ import seedu.address.model.link.Link;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleTitle;
+import seedu.address.model.module.exceptions.ModuleNotFoundException;
 import seedu.address.model.module.task.Task;
 import seedu.address.model.module.task.TaskList;
 
@@ -59,16 +61,16 @@ public class DeleteTaskCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Module> lastShownList = model.getFilteredModuleList();
+        ModuleCode moduleCodeOfTaskToDeleteTaskFrom =
+                deleteTaskFromModuleDescriptor.moduleCodeOfModuleWithTaskToDelete;
         Module moduleToDeleteTaskFrom = null;
-        // Search for module with matching module code.
-        for (Module module : lastShownList) {
-            if (module.getModuleCode().equals(deleteTaskFromModuleDescriptor.moduleCodeOfModuleWithTaskToDelete)) {
-                moduleToDeleteTaskFrom = module;
-            }
+        try {
+            moduleToDeleteTaskFrom =
+                    model.getModuleUsingModuleCode(moduleCodeOfTaskToDeleteTaskFrom, true);
+        } catch (ModuleNotFoundException e) {
+            throw new CommandException(Messages.MESSAGE_NO_SUCH_MODULE);
         }
-        if (moduleToDeleteTaskFrom == null) {
-            throw new CommandException(MESSAGE_MODULE_CODE_DOES_NOT_EXIST);
-        }
+        assert moduleToDeleteTaskFrom != null;
         int indexOfTaskToDelete = deleteTaskFromModuleDescriptor
                 .getTaskIndexToDelete().getZeroBased();
         int numberOfTasksInTaskList = moduleToDeleteTaskFrom.getTasks().size();

--- a/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteTaskCommand.java
@@ -42,8 +42,6 @@ public class DeleteTaskCommand extends Command {
             "Deleted task from: %1$s";
     public static final String MESSAGE_TASK_NUMBER_DOES_NOT_EXIST =
             "Task number given does not exist.";
-    public static final String MESSAGE_MODULE_CODE_DOES_NOT_EXIST =
-            "The given module code does not exist!";
 
     private final DeleteTaskFromModuleDescriptor deleteTaskFromModuleDescriptor;
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javafx.collections.ObservableList;
 import seedu.address.model.module.Module;
 import seedu.address.model.module.UniqueModuleList;
+import seedu.address.model.module.exceptions.ModuleNotFoundException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -142,6 +143,19 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(editedModule);
 
         modules.setModule(target, editedModule);
+    }
+
+    /**
+     * Returns the {@code Module} in {@code modules} with the matching module
+     * code as the given {@code module}.
+     * @param module Module with the module code which we would like to
+     *               search for.
+     * @return {@code Module} with the same module code as the given
+     *         {@code module} argument.
+     */
+    public Module getModule(Module module) throws ModuleNotFoundException {
+        requireNonNull(module);
+        return modules.getModule(module);
     }
 
     //// util methods

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -180,7 +180,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddressBook // instanceof handles nulls
-                && persons.equals(((AddressBook) other).persons));
+                && persons.equals(((AddressBook) other).persons)
+                && modules.equals(((AddressBook) other).modules));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,8 @@ import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.exceptions.ModuleNotFoundException;
 import seedu.address.model.person.Person;
 
 /**
@@ -98,6 +100,12 @@ public interface Model {
     boolean hasModule(Module module);
 
     /**
+     * Returns true if a module with the same identity as {@code module}
+     * exists in the filtered list of modules being displayed to the user.
+     */
+    boolean hasModuleInFilteredList(Module module);
+
+    /**
      * Deletes the given module.
      * The module must exist in the address book.
      */
@@ -121,4 +129,19 @@ public interface Model {
 
     /** Returns an unmodifiable view of the filtered module list */
     ObservableList<Module> getFilteredModuleList();
+
+    /**
+     * Searches for and retrieves a module currently present in the address
+     * book using the module code. Depending on the {@code isFiltered}
+     * parameter, we can choose to search in the full list of modules in the
+     * address book or only search from the current filtered list of modules
+     * being displayed to the user.
+     * @param moduleCodeOfModuleToGet {@code ModuleCode} of the module we would
+     *                                like to search for and retrieve.
+     * @param isFiltered {@boolean} value of whether the search should be
+     *                   conducted in the full list or filtered list.
+     * @return {@code Module} with the specified {@code ModuleCode}
+     */
+    Module getModuleUsingModuleCode(ModuleCode moduleCodeOfModuleToGet,
+                                    boolean isFiltered) throws ModuleNotFoundException;
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -12,6 +12,8 @@ import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.exceptions.ModuleNotFoundException;
 import seedu.address.model.person.Person;
 
 /**
@@ -121,6 +123,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasModuleInFilteredList(Module module) {
+        requireNonNull(module);
+        return filteredModules.stream().anyMatch(module::isSameModule);
+    }
+
+    @Override
     public void deleteModule(Module target) {
         addressBook.removeModule(target);
     }
@@ -136,6 +144,27 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedModule);
 
         addressBook.setModule(target, editedModule);
+    }
+
+    @Override
+    public Module getModuleUsingModuleCode(ModuleCode moduleCodeOfModuleToGet,
+                                           boolean isFiltered) {
+        requireAllNonNull(moduleCodeOfModuleToGet, isFiltered);
+        Module moduleToGet = new Module(moduleCodeOfModuleToGet);
+        if (isFiltered && hasModuleInFilteredList(moduleToGet)) {
+            ObservableList<Module> unmodifiableListOfModules =
+                    this.getFilteredModuleList();
+            // There should only be one module in the filtered module list with
+            // the same module code.
+            assert filteredModules.stream().filter(moduleToGet::isSameModule).count() == 1;
+            return filteredModules.stream()
+                                  .filter(moduleToGet::isSameModule)
+                                  .findFirst().get();
+        } else if (!isFiltered && hasModule(moduleToGet)) {
+            return addressBook.getModule(moduleToGet);
+        } else {
+            throw new ModuleNotFoundException();
+        }
     }
 
     //=========== Filtered Person List Accessors =============================================================
@@ -191,5 +220,4 @@ public class ModelManager implements Model {
                 && filteredPersons.equals(other.filteredPersons)
                 && filteredModules.equals(other.filteredModules);
     }
-
 }

--- a/src/main/java/seedu/address/model/module/UniqueModuleList.java
+++ b/src/main/java/seedu/address/model/module/UniqueModuleList.java
@@ -69,6 +69,27 @@ public class UniqueModuleList implements Iterable<Module> {
     }
 
     /**
+     * Returns the {@code Module} with the same {@code ModuleCode} as the
+     * {@code Module} supplied as the argument.
+     * @param module {@code Module} with the {@code ModuleCode} of the
+     *               {@code Module} we would like to retrieve.
+     * @throws ModuleNotFoundException when there does not exist a {@code Module}
+     *                                 with the same {@code ModuleCode} as the
+     *                                 supplied argument.
+     */
+    public Module getModule(Module module) throws ModuleNotFoundException {
+        if (contains(module)) {
+            // There should only be one existing module with the same module code.
+            assert internalList.stream().filter(module::isSameModule).count() == 1;
+            return internalUnmodifiableList.stream()
+                                           .filter(module::isSameModule)
+                                           .findFirst().get();
+        } else {
+            throw new ModuleNotFoundException();
+        }
+    }
+
+    /**
      * Removes the equivalent module from the list.
      * The module must exist in the list.
      */

--- a/src/test/data/JsonSerializableAddressBookTest/typicalModulesAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalModulesAddressBook.json
@@ -4,7 +4,7 @@
   "modules" : [ {
     "moduleCode": "CS2103T",
     "moduleTitle": "Software Engineering",
-    "tasks" : [ "Submit quiz" ]
+    "tasks" : [ ]
   }, {
     "moduleCode": "CS2106",
     "moduleTitle": "Introduction to Operating Systems",
@@ -13,5 +13,10 @@
     "moduleCode": "MA2001",
     "moduleTitle": "Linear Algebra I",
     "tasks" : [ ]
+  }, {
+    "moduleCode": "GE3238",
+    "moduleTitle": "GIS Design and Practices",
+    "tasks" : [ ],
+    "linked" : ["qgis.org", "www.arcgis.com"]
   }]
 }

--- a/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.AddTaskCommand.AddTaskToModuleDescriptor;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
@@ -80,7 +81,7 @@ public class AddTaskCommandTest {
         AddTaskCommand addTaskCommand = new AddTaskCommand(descriptor);
 
         assertThrows(CommandException.class,
-                AddTaskCommand.MESSAGE_MODULE_CODE_DOES_NOT_EXIST, () ->
+                Messages.MESSAGE_NO_SUCH_MODULE, () ->
                 addTaskCommand.execute(model));
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteTaskCommandTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteTaskCommand.DeleteTaskFromModuleDescriptor;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -62,7 +63,7 @@ public class DeleteTaskCommandTest {
         DeleteTaskCommand deleteTaskCommand = new DeleteTaskCommand(descriptor);
 
         assertThrows(CommandException.class,
-                AddTaskCommand.MESSAGE_MODULE_CODE_DOES_NOT_EXIST, () ->
+                Messages.MESSAGE_NO_SUCH_MODULE, () ->
                         deleteTaskCommand.execute(model));
     }
     @Test

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -134,7 +134,6 @@ public class AddressBookTest {
         addressBook.addModule(CS2106);
         assertEquals(CS2106, addressBook.getModule(moduleWithSameModuleCode));
     }
-    
     /**
      * A stub ReadOnlyAddressBook whose persons list can violate interface constraints.
      */

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBookWithOnlyPersons;
+import static seedu.address.testutil.TypicalModules.CS2106;
+import static seedu.address.testutil.TypicalModules.MA2001;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 
 import java.util.Arrays;
@@ -17,8 +19,10 @@ import org.junit.jupiter.api.Test;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.exceptions.ModuleNotFoundException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.testutil.ModuleBuilder;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddressBookTest {
@@ -28,6 +32,7 @@ public class AddressBookTest {
     @Test
     public void constructor() {
         assertEquals(Collections.emptyList(), addressBook.getPersonList());
+        assertEquals(Collections.emptyList(), addressBook.getModuleList());
     }
 
     @Test
@@ -80,6 +85,56 @@ public class AddressBookTest {
         assertThrows(UnsupportedOperationException.class, () -> addressBook.getPersonList().remove(0));
     }
 
+    @Test
+    public void hasModule_nullModule_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.hasModule(null));
+    }
+
+    @Test
+    public void hasModule_moduleNotInAddressBook_returnsFalse() {
+        assertFalse(addressBook.hasModule(CS2106));
+        assertFalse(addressBook.hasModule(MA2001));
+    }
+
+    @Test
+    public void hasModule_moduleInAddressBook_returnsTrue() {
+        addressBook.addModule(CS2106);
+        assertTrue(addressBook.hasModule(CS2106));
+    }
+
+    @Test
+    public void hasModule_moduleWithSameModuleCodeInAddressBook_returnsTrue() {
+        Module moduleWithSameModuleCode =
+                new ModuleBuilder().withModuleCode(CS2106.getModuleCode().value).build();
+        addressBook.addModule(CS2106);
+        assertTrue(addressBook.hasModule(moduleWithSameModuleCode));
+    }
+
+    @Test
+    public void getModule_nullModule_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> addressBook.getModule(null));
+    }
+
+    @Test
+    public void getModule_moduleNotInAddressBook_throwsModuleNotFoundException() {
+        assertThrows(ModuleNotFoundException.class, () -> addressBook.getModule(CS2106));
+        assertThrows(ModuleNotFoundException.class, () -> addressBook.getModule(MA2001));
+    }
+
+    @Test
+    public void getModule_moduleInAddressBook_returnsTrue() {
+        addressBook.addModule(CS2106);
+        assertEquals(CS2106, addressBook.getModule(CS2106));
+    }
+
+    @Test
+    public void getModule_moduleWithSameModuleCodeInAddressBook_returnsTrue() {
+        Module moduleWithSameModuleCode =
+                new ModuleBuilder().withModuleCode(CS2106.getModuleCode().value).build();
+        addressBook.addModule(CS2106);
+        assertEquals(CS2106, addressBook.getModule(moduleWithSameModuleCode));
+    }
+    
     /**
      * A stub ReadOnlyAddressBook whose persons list can violate interface constraints.
      */

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -3,8 +3,11 @@ package seedu.address.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_MODULES;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalModules.CS2106;
+import static seedu.address.testutil.TypicalModules.MA2001;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
 
@@ -15,8 +18,13 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
+import seedu.address.model.module.ModuleCodeMatchesKeywordPredicate;
+import seedu.address.model.module.exceptions.ModuleNotFoundException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.testutil.AddressBookBuilder;
+import seedu.address.testutil.ModuleBuilder;
 
 public class ModelManagerTest {
 
@@ -89,13 +97,130 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void hasModule_nullModule_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasModule(null));
+    }
+
+    @Test
+    public void hasModule_moduleNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasModule(CS2106));
+    }
+
+    @Test
+    public void hasModule_moduleInAddressBook_returnsTrue() {
+        modelManager.addModule(CS2106);
+        assertTrue(modelManager.hasModule(CS2106));
+    }
+
+    @Test
+    public void hasModule_moduleInAddressBookButNotInFilteredList_returnsTrue() {
+        modelManager.addModule(CS2106);
+        String keywordToFilterBy = MA2001.getModuleCodeAsUpperCaseString();
+        modelManager.updateFilteredModuleList(new ModuleCodeMatchesKeywordPredicate(keywordToFilterBy));
+        assertTrue(modelManager.hasModule(CS2106));
+    }
+
+    @Test
+    public void hasModule_moduleWithSameModuleCodeButDifferentFieldsInAddressBook_returnsTrue() {
+        String moduleCodeToCheckFor = CS2106.getModuleCode().value;
+        Module moduleWithModuleSameCodeButDifferentFields =
+                new ModuleBuilder().withModuleCode(moduleCodeToCheckFor).build();
+        modelManager.addModule(CS2106);
+        assertTrue(modelManager.hasModule(moduleWithModuleSameCodeButDifferentFields));
+    }
+
+    @Test
+    public void hasModuleInFilteredList_nullModule_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasModuleInFilteredList(null));
+    }
+
+    @Test
+    public void hasModuleInFilteredList_moduleNotInAddressBook_returnsFalse() {
+        assertFalse(modelManager.hasModuleInFilteredList(CS2106));
+    }
+
+    @Test
+    public void hasModuleInFilteredList_moduleInAddressBookAndFilteredList_returnsTrue() {
+        modelManager.addModule(CS2106);
+        assertTrue(modelManager.hasModuleInFilteredList(CS2106));
+    }
+
+    @Test
+    public void hasModuleInFilteredList_moduleInAddressBookButNotInFilteredList_returnsFalse() {
+        modelManager.addModule(CS2106);
+        String keywordToFilterBy = MA2001.getModuleCodeAsUpperCaseString();
+        modelManager.updateFilteredModuleList(new ModuleCodeMatchesKeywordPredicate(keywordToFilterBy));
+        assertFalse(modelManager.hasModuleInFilteredList(CS2106));
+    }
+
+    @Test
+    public void hasModuleInFilteredList_moduleWithSameModuleCodeButDifferentFieldsInFilteredList_returnsTrue() {
+        String moduleCodeToCheckFor = CS2106.getModuleCode().value;
+        Module moduleWithModuleSameCodeButDifferentFields =
+                new ModuleBuilder().withModuleCode(moduleCodeToCheckFor).build();
+        modelManager.addModule(CS2106);
+        assertTrue(modelManager.hasModule(moduleWithModuleSameCodeButDifferentFields));
+    }
+
+    @Test
+    public void getModuleUsingModuleCode_nullModuleCode_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () ->
+                modelManager.getModuleUsingModuleCode(null, true));
+    }
+
+    @Test
+    public void getModuleUsingModuleCode_moduleNotInAddressBookOrFilteredModuleList_throwsModuleNotFoundException() {
+        ModuleCode moduleCodeToSearchFor = CS2106.getModuleCode();
+        // Get from filtered list.
+        assertThrows(ModuleNotFoundException.class, () ->
+                modelManager.getModuleUsingModuleCode(moduleCodeToSearchFor, true));
+        // Get from address book.
+        assertThrows(ModuleNotFoundException.class, () ->
+                modelManager.getModuleUsingModuleCode(moduleCodeToSearchFor, false));
+    }
+
+    @Test
+    public void getModuleUsingModuleCode_moduleInAddressBookAndFilteredList_returnsModule() {
+        ModuleCode moduleCodeToSearchFor = CS2106.getModuleCode();
+        modelManager.addModule(CS2106);
+        assertEquals(CS2106, modelManager.getModuleUsingModuleCode(moduleCodeToSearchFor, true));
+        assertEquals(CS2106, modelManager.getModuleUsingModuleCode(moduleCodeToSearchFor, false));
+    }
+
+    @Test
+    public void
+            getModuleUsingModuleCode_moduleInAddressBookButNotInFilteredListAndSearchInAddressBook_returnsModule() {
+        modelManager.addModule(CS2106);
+        String keywordToFilterBy = MA2001.getModuleCodeAsUpperCaseString();
+        modelManager.updateFilteredModuleList(new ModuleCodeMatchesKeywordPredicate(keywordToFilterBy));
+        assertEquals(CS2106, modelManager.getModuleUsingModuleCode(CS2106.getModuleCode(), false));
+    }
+
+    @Test
+    public void
+            getModuleUsingModuleCode_moduleInAddressBookButNotInFilteredListAndSearchInFilteredList_returnsModule() {
+        modelManager.addModule(CS2106);
+        String keywordToFilterBy = MA2001.getModuleCodeAsUpperCaseString();
+        modelManager.updateFilteredModuleList(new ModuleCodeMatchesKeywordPredicate(keywordToFilterBy));
+        assertThrows(ModuleNotFoundException.class, () ->
+                modelManager.getModuleUsingModuleCode(CS2106.getModuleCode(), true));
+    }
+
+    @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredPersonList().remove(0));
     }
 
     @Test
+    public void getFilteredModuleList_modifyList_throwsUnsupportedOperationException() {
+        assertThrows(UnsupportedOperationException.class, () -> modelManager.getFilteredModuleList().remove(0));
+    }
+
+
+    @Test
     public void equals() {
-        AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
+        AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON)
+                                                          .withModule(CS2106).build();
         AddressBook differentAddressBook = new AddressBook();
         UserPrefs userPrefs = new UserPrefs();
 
@@ -116,13 +241,21 @@ public class ModelManagerTest {
         // different addressBook -> returns false
         assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs)));
 
-        // different filteredList -> returns false
+        // different filteredPersonList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
         modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        // different filteredModuleList -> returns false
+        String keywordToFilterBy = MA2001.getModuleCodeAsUpperCaseString();
+        modelManager.updateFilteredModuleList(new ModuleCodeMatchesKeywordPredicate(keywordToFilterBy));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
+
+        // resets modelManager to initial state for upcoming tests
+        modelManager.updateFilteredModuleList(PREDICATE_SHOW_ALL_MODULES);
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();

--- a/src/test/java/seedu/address/model/module/UniqueModuleListTest.java
+++ b/src/test/java/seedu/address/model/module/UniqueModuleListTest.java
@@ -3,6 +3,7 @@ package seedu.address.model.module;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CS_MODULE_CODE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MA_MODULE_TITLE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalModules.CS2106;
@@ -161,6 +162,35 @@ public class UniqueModuleListTest {
     public void setModules_listWithDuplicateModules_throwsDuplicateModuleException() {
         List<Module> listWithDuplicateModules = Arrays.asList(CS2106, CS2106);
         assertThrows(DuplicateModuleException.class, () -> uniqueModuleList.setModules(listWithDuplicateModules));
+    }
+
+    @Test
+    public void getModule_nullModule_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueModuleList.getModule(null));
+    }
+
+    @Test
+    public void getModule_moduleDoesNotExist_throwsModuleNotFoundException() {
+        assertThrows(ModuleNotFoundException.class, () -> uniqueModuleList.getModule(CS2106));
+    }
+
+    @Test
+    public void getModule_existingModuleWithSameExactFields_returnsModule() {
+        Module expectedModule = CS2106;
+        uniqueModuleList.add(expectedModule);
+        Module retrievedModule = uniqueModuleList.getModule(expectedModule);
+        assertEquals(expectedModule, retrievedModule);
+    }
+
+    @Test
+    public void getModule_existingModuleWithSameModuleCodeButDifferentFields_returnsModule() {
+        Module expectedModule = CS2106;
+        uniqueModuleList.add(CS2106);
+
+        Module moduleWithDifferentFields =
+                new ModuleBuilder().withModuleCode(VALID_CS_MODULE_CODE).build();
+        Module retrievedModule = uniqueModuleList.getModule(moduleWithDifferentFields);
+        assertEquals(expectedModule, retrievedModule);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/AddressBookBuilder.java
+++ b/src/test/java/seedu/address/testutil/AddressBookBuilder.java
@@ -1,6 +1,7 @@
 package seedu.address.testutil;
 
 import seedu.address.model.AddressBook;
+import seedu.address.model.module.Module;
 import seedu.address.model.person.Person;
 
 /**
@@ -25,6 +26,14 @@ public class AddressBookBuilder {
      */
     public AddressBookBuilder withPerson(Person person) {
         addressBook.addPerson(person);
+        return this;
+    }
+
+    /**
+     * Adds a new {@code Module} to the {@code AddressBook} that we are building.
+     */
+    public AddressBookBuilder withModule(Module module) {
+        addressBook.addModule(module);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/ModelStub.java
+++ b/src/test/java/seedu/address/testutil/ModelStub.java
@@ -9,6 +9,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.module.Module;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.person.Person;
 
 /**
@@ -92,6 +93,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public boolean hasModuleInFilteredList(Module module) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public void deleteModule(Module target) {
         throw new AssertionError("This method should not be called.");
     }
@@ -103,6 +109,12 @@ public class ModelStub implements Model {
 
     @Override
     public void setModule(Module target, Module editedModule) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Module getModuleUsingModuleCode(ModuleCode moduleCode,
+                                         boolean isFiltered) {
         throw new AssertionError("This method should not be called.");
     }
 


### PR DESCRIPTION
## 1. A unified method to search and retrieve `Module`s using the `ModuleCode`
Currently, there isn't an efficient way of retrieving modules present in `AddressBook::modules` or in `ModelManager::filteredModules` as a `Module` object using only the `ModuleCode`. 

As such, the main purpose of this PR is to introduce the `getModuleFromModuleCode` method. 

## 2. More tests for `Module` -related methods in `AddressBook` and `ModelManager`
In `v1.2`, there were no tests added to  `AddressBook` and `ModelManager` despite the introduction of multiple `module`-related methods.

As such more unit tests were added to `AddressBookTest` and `ModelManagerTest` to test these  `module`-related methods.

## 3. Fixing of bug in `AddressBook::equals`
The tests added in point 2 above discovered a bug in the current implementation of `AddressBook`, where the `equals` method fails to compare the modules present in the `AddressBook` being compared. This issue has been fixed in this PR.