### PR TITLE
Implement display contacts of module (upon navigation) feature

### DIFF
--- a/src/main/java/seedu/address/logic/parser/GoToCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/GoToCommandParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import seedu.address.logic.commands.GoToCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleCodeMatchesKeywordPredicate;
 
 /**
@@ -22,6 +23,8 @@ public class GoToCommandParser implements Parser<GoToCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, GoToCommand.MESSAGE_USAGE));
         }
 
-        return new GoToCommand(new ModuleCodeMatchesKeywordPredicate(trimmedArgs));
+        ModuleCode moduleCode = ParserUtil.parseModuleCode(trimmedArgs);
+
+        return new GoToCommand(new ModuleCodeMatchesKeywordPredicate(trimmedArgs), moduleCode);
     }
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -18,6 +18,9 @@ public interface Model {
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
     Predicate<Module> PREDICATE_SHOW_ALL_MODULES = unused -> true;
 
+    /** {@code Predicate} that always evaluate to false */
+    Predicate<Person> PREDICATE_SHOW_ZERO_PERSON = unused -> false;
+
     //// person-related methods
 
     /**

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -129,11 +129,10 @@ public class Module {
     }
 
     /**
-     * Returns an immutable {@code Person} list, which throws {@code UnsupportedOperationException}
-     * if modification is attempted.
+     * Returns a copy of {@code Person} list.
      */
     public List<Person> getListOfPersons() {
-        return listOfPersons;
+        return new ArrayList<>(listOfPersons);
     }
 
 
@@ -168,13 +167,14 @@ public class Module {
         return otherModule.getModuleCode().equals(getModuleCode())
                 && otherModule.getModuleTitle().equals(getModuleTitle())
                 && otherModule.getLinks().equals(getLinks())
-                && otherModule.getTasks().equals(getTasks());
+                && otherModule.getTasks().equals(getTasks())
+                && otherModule.getListOfPersons().equals(getListOfPersons());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(moduleCode, links, tasks);
+        return Objects.hash(moduleCode, links, tasks, listOfPersons);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -2,7 +2,6 @@ package seedu.address.model.module;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -31,7 +30,7 @@ public class Module {
     private final ModuleTitle moduleTitle;
     private final TaskList tasks;
     private final Set<Link> links = new HashSet<>();
-    private final List<Person> listOfPersons = new ArrayList<>();
+    private final Set<Person> persons = new HashSet<>();
 
     /**
      * Every field must be present and not null.
@@ -129,12 +128,12 @@ public class Module {
     }
 
     /**
-     * Returns a copy of {@code Person} list.
+     * Returns an immutable person set, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
      */
-    public List<Person> getListOfPersons() {
-        return new ArrayList<>(listOfPersons);
+    public Set<Person> getPersons() {
+        return Collections.unmodifiableSet(persons);
     }
-
 
     /**
      * Returns true if both modules have the same moduleCode.
@@ -168,13 +167,13 @@ public class Module {
                 && otherModule.getModuleTitle().equals(getModuleTitle())
                 && otherModule.getLinks().equals(getLinks())
                 && otherModule.getTasks().equals(getTasks())
-                && otherModule.getListOfPersons().equals(getListOfPersons());
+                && otherModule.getPersons().equals(getPersons());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(moduleCode, links, tasks, listOfPersons);
+        return Objects.hash(moduleCode, links, tasks, persons);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -2,6 +2,7 @@ package seedu.address.model.module;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -12,6 +13,7 @@ import javafx.collections.ObservableList;
 import seedu.address.model.link.Link;
 import seedu.address.model.module.task.Task;
 import seedu.address.model.module.task.TaskList;
+import seedu.address.model.person.Person;
 
 /**
  * Represents a Module in the address book.
@@ -29,6 +31,7 @@ public class Module {
     private final ModuleTitle moduleTitle;
     private final TaskList tasks;
     private final Set<Link> links = new HashSet<>();
+    private final List<Person> listOfPersons = new ArrayList<>();
 
     /**
      * Every field must be present and not null.
@@ -106,7 +109,7 @@ public class Module {
      * Returns a copied links set
      */
     public Set<Link> copyLinks() {
-        return new HashSet<Link>(links);
+        return new HashSet<>(links);
     }
 
     /**
@@ -123,6 +126,14 @@ public class Module {
      */
     public Boolean hasDuplicateTasks() {
         return tasks.containsDuplicate();
+    }
+
+    /**
+     * Returns an immutable {@code Person} list, which throws {@code UnsupportedOperationException}
+     * if modification is attempted.
+     */
+    public List<Person> getListOfPersons() {
+        return listOfPersons;
     }
 
 

--- a/src/main/java/seedu/address/model/person/PersonIsInModulePredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonIsInModulePredicate.java
@@ -1,0 +1,36 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.model.module.Module;
+
+/**
+ * Tests that a {@code Person} is in the list of {@code Person}s of the given {@code Module}.
+ */
+public class PersonIsInModulePredicate implements Predicate<Person> {
+    private final List<Person> listOfPersonsInModule;
+
+    /**
+     * Obtains the list of {@code Person}s in the given {@code Module} and assigns it to the relevant field.
+     *
+     * @param module The {@code Module} to obtain list of {@code Person}s from.
+     */
+    public PersonIsInModulePredicate(Module module) {
+        List<Person> listOfPersonsInModule = module.getListOfPersons();
+        this.listOfPersonsInModule = listOfPersonsInModule;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return listOfPersonsInModule.contains(person);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PersonIsInModulePredicate // instanceof handles nulls
+                && listOfPersonsInModule.equals(((PersonIsInModulePredicate) other).listOfPersonsInModule));
+        // state check
+    }
+}

--- a/src/main/java/seedu/address/model/person/PersonIsInModulePredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonIsInModulePredicate.java
@@ -1,6 +1,6 @@
 package seedu.address.model.person;
 
-import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.address.model.module.Module;
@@ -9,7 +9,7 @@ import seedu.address.model.module.Module;
  * Tests that a {@code Person} is in the list of {@code Person}s of the given {@code Module}.
  */
 public class PersonIsInModulePredicate implements Predicate<Person> {
-    private final List<Person> listOfPersonsInModule;
+    private final Set<Person> setOfPersonsInModule;
 
     /**
      * Obtains the list of {@code Person}s in the given {@code Module} and assigns it to the relevant field.
@@ -17,20 +17,19 @@ public class PersonIsInModulePredicate implements Predicate<Person> {
      * @param module The {@code Module} to obtain list of {@code Person}s from.
      */
     public PersonIsInModulePredicate(Module module) {
-        List<Person> listOfPersonsInModule = module.getListOfPersons();
-        this.listOfPersonsInModule = listOfPersonsInModule;
+        this.setOfPersonsInModule = module.getPersons();
     }
 
     @Override
     public boolean test(Person person) {
-        return listOfPersonsInModule.contains(person);
+        return setOfPersonsInModule.contains(person);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof PersonIsInModulePredicate // instanceof handles nulls
-                && listOfPersonsInModule.equals(((PersonIsInModulePredicate) other).listOfPersonsInModule));
+                && setOfPersonsInModule.equals(((PersonIsInModulePredicate) other).setOfPersonsInModule));
         // state check
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -48,6 +48,7 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
     public static final String VALID_CS_MODULE_CODE = "CS2106";
+    public static final String VALID_CS_MODULE_CODE_NOT_IN_TYPICAL_ADDRESS_BOOK = "CS9999";
     public static final String VALID_CS_MODULE_TITLE = "Introduction to Operating Systems";
     public static final String VALID_MA_MODULE_CODE = "MA2001";
     public static final String VALID_MA_MODULE_TITLE = "Linear Algebra I";

--- a/src/test/java/seedu/address/logic/commands/GoToCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GoToCommandTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_MODULE_LISTED;
 import static seedu.address.commons.core.Messages.MESSAGE_NO_SUCH_MODULE;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_CS_MODULE_CODE_NOT_IN_TYPICAL_ADDRESS_BOOK;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CS9999_MODULE_CODE_NOT_IN_TYPICAL_ADDRESS_BOOK;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
@@ -66,8 +66,8 @@ public class GoToCommandTest {
     public void execute_nonMatchingKeywords_noModuleFound() {
         String expectedMessage = MESSAGE_NO_SUCH_MODULE;
         ModuleCodeMatchesKeywordPredicate predicate =
-                new ModuleCodeMatchesKeywordPredicate(VALID_CS_MODULE_CODE_NOT_IN_TYPICAL_ADDRESS_BOOK);
-        ModuleCode moduleCode = new ModuleCode(VALID_CS_MODULE_CODE_NOT_IN_TYPICAL_ADDRESS_BOOK);
+                new ModuleCodeMatchesKeywordPredicate(VALID_CS9999_MODULE_CODE_NOT_IN_TYPICAL_ADDRESS_BOOK);
+        ModuleCode moduleCode = new ModuleCode(VALID_CS9999_MODULE_CODE_NOT_IN_TYPICAL_ADDRESS_BOOK);
         GoToCommand command = new GoToCommand(predicate, moduleCode);
 
         assertThrows(CommandException.class,

--- a/src/test/java/seedu/address/logic/commands/GoToCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GoToCommandTest.java
@@ -5,20 +5,24 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_MODULE_LISTED;
 import static seedu.address.commons.core.Messages.MESSAGE_NO_SUCH_MODULE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_CS_MODULE_CODE_NOT_IN_TYPICAL_ADDRESS_BOOK;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalModules.CS2106;
 import static seedu.address.testutil.TypicalModules.MA2001;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleCodeMatchesKeywordPredicate;
+import seedu.address.model.person.PersonIsInModulePredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code GoToCommand}.
@@ -35,15 +39,17 @@ public class GoToCommandTest {
                 new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_CS2106);
         ModuleCodeMatchesKeywordPredicate secondPredicate =
                 new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_MA2001);
+        ModuleCode firstModuleCode = new ModuleCode(MODULE_CODE_STR_CS2106);
+        ModuleCode secondModuleCode = new ModuleCode(MODULE_CODE_STR_CS2106);
 
-        GoToCommand gotoFirstCommand = new GoToCommand(firstPredicate);
-        GoToCommand gotoSecondCommand = new GoToCommand(secondPredicate);
+        GoToCommand gotoFirstCommand = new GoToCommand(firstPredicate, firstModuleCode);
+        GoToCommand gotoSecondCommand = new GoToCommand(secondPredicate, secondModuleCode);
 
         // same object -> returns true
         assertTrue(gotoFirstCommand.equals(gotoFirstCommand));
 
         // same values -> returns true
-        GoToCommand gotoFirstCommandCopy = new GoToCommand(firstPredicate);
+        GoToCommand gotoFirstCommandCopy = new GoToCommand(firstPredicate, firstModuleCode);
         assertTrue(gotoFirstCommand.equals(gotoFirstCommandCopy));
 
         // different types -> returns false
@@ -57,13 +63,16 @@ public class GoToCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
+    public void execute_nonMatchingKeywords_noModuleFound() {
         String expectedMessage = MESSAGE_NO_SUCH_MODULE;
-        ModuleCodeMatchesKeywordPredicate predicate = new ModuleCodeMatchesKeywordPredicate(" ");
-        GoToCommand command = new GoToCommand(predicate);
-        expectedModel.updateFilteredModuleList(predicate);
-        assertCommandSuccess(command, model, expectedMessage, expectedModel);
-        assertEquals(Collections.emptyList(), model.getFilteredModuleList());
+        ModuleCodeMatchesKeywordPredicate predicate =
+                new ModuleCodeMatchesKeywordPredicate(VALID_CS_MODULE_CODE_NOT_IN_TYPICAL_ADDRESS_BOOK);
+        ModuleCode moduleCode = new ModuleCode(VALID_CS_MODULE_CODE_NOT_IN_TYPICAL_ADDRESS_BOOK);
+        GoToCommand command = new GoToCommand(predicate, moduleCode);
+
+        assertThrows(CommandException.class,
+                expectedMessage, ()
+                        -> command.execute(model));
     }
 
     @Test
@@ -71,11 +80,20 @@ public class GoToCommandTest {
         String expectedMessage = MESSAGE_MODULE_LISTED;
 
         // Matching keyword test
-        ModuleCodeMatchesKeywordPredicate predicate = new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_CS2106);
-        GoToCommand command = new GoToCommand(predicate);
-        expectedModel.updateFilteredModuleList(predicate);
+        ModuleCodeMatchesKeywordPredicate predicateToFilterModule =
+                new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_CS2106);
+        PersonIsInModulePredicate predicateToFilterPerson = new PersonIsInModulePredicate(CS2106);
+        ModuleCode moduleCode = new ModuleCode(MODULE_CODE_STR_CS2106);
+        GoToCommand command = new GoToCommand(predicateToFilterModule, moduleCode);
+
+        expectedModel.updateFilteredModuleList(predicateToFilterModule);
+        expectedModel.updateFilteredPersonList(predicateToFilterPerson);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CS2106), model.getFilteredModuleList());
+
+        // To be updated when moduleBuilder has in-built list of persons to
+        // assertEquals(Arrays.asList(...), model.getFilteredPersonList())
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
     }
 
     @Test
@@ -83,10 +101,17 @@ public class GoToCommandTest {
         String expectedMessage = MESSAGE_MODULE_LISTED;
 
         // Case-insensitive keyword test
-        ModuleCodeMatchesKeywordPredicate predicate = new ModuleCodeMatchesKeywordPredicate("cS2106");
-        GoToCommand command = new GoToCommand(predicate);
-        expectedModel.updateFilteredModuleList(predicate);
+        ModuleCodeMatchesKeywordPredicate predicateToFilterModule = new ModuleCodeMatchesKeywordPredicate("cS2106");
+        PersonIsInModulePredicate predicateToFilterPerson = new PersonIsInModulePredicate(CS2106);
+        ModuleCode moduleCode = new ModuleCode(MODULE_CODE_STR_CS2106);
+        GoToCommand command = new GoToCommand(predicateToFilterModule, moduleCode);
+
+        expectedModel.updateFilteredModuleList(predicateToFilterModule);
+        expectedModel.updateFilteredPersonList(predicateToFilterPerson);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CS2106), model.getFilteredModuleList());
+        // To be updated when moduleBuilder has in-built list of persons to
+        // assertEquals(Arrays.asList(...), model.getFilteredPersonList())
+        assertEquals(expectedModel.getFilteredPersonList(), model.getFilteredPersonList());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/GoToCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/GoToCommandTest.java
@@ -40,7 +40,7 @@ public class GoToCommandTest {
         ModuleCodeMatchesKeywordPredicate secondPredicate =
                 new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_MA2001);
         ModuleCode firstModuleCode = new ModuleCode(MODULE_CODE_STR_CS2106);
-        ModuleCode secondModuleCode = new ModuleCode(MODULE_CODE_STR_CS2106);
+        ModuleCode secondModuleCode = new ModuleCode(MODULE_CODE_STR_MA2001);
 
         GoToCommand gotoFirstCommand = new GoToCommand(firstPredicate, firstModuleCode);
         GoToCommand gotoSecondCommand = new GoToCommand(secondPredicate, secondModuleCode);
@@ -60,6 +60,12 @@ public class GoToCommandTest {
 
         // different module -> returns false
         assertFalse(gotoFirstCommand.equals(gotoSecondCommand));
+
+        // different predicate -> returns false
+        assertFalse(gotoFirstCommand.equals(new GoToCommand(secondPredicate, firstModuleCode)));
+
+        // different moduleCode -> returns false
+        assertFalse(gotoFirstCommand.equals(new GoToCommand(firstPredicate, secondModuleCode)));
     }
 
     @Test
@@ -70,9 +76,7 @@ public class GoToCommandTest {
         ModuleCode moduleCode = new ModuleCode(VALID_CS9999_MODULE_CODE_NOT_IN_TYPICAL_ADDRESS_BOOK);
         GoToCommand command = new GoToCommand(predicate, moduleCode);
 
-        assertThrows(CommandException.class,
-                expectedMessage, ()
-                        -> command.execute(model));
+        assertThrows(CommandException.class, expectedMessage, () -> command.execute(model));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/GoToCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/GoToCommandParserTest.java
@@ -57,7 +57,7 @@ public class GoToCommandParserTest {
     }
 
     @Test
-    public void parse_validArgs_returnsFindCommand() {
+    public void parse_validArgs_returnsGoToCommand() {
         GoToCommand expectedGoToCommand =
                 new GoToCommand(new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_CS2106),
                         new ModuleCode(MODULE_CODE_STR_CS2106));

--- a/src/test/java/seedu/address/logic/parser/GoToCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/GoToCommandParserTest.java
@@ -12,6 +12,7 @@ import static seedu.address.testutil.TypicalModules.MA2001;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.GoToCommand;
+import seedu.address.model.module.ModuleCode;
 import seedu.address.model.module.ModuleCodeMatchesKeywordPredicate;
 
 public class GoToCommandParserTest {
@@ -24,16 +25,19 @@ public class GoToCommandParserTest {
     @Test
     public void equals() {
         GoToCommand firstGoToCommand =
-                new GoToCommand(new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_CS2106));
+                new GoToCommand(new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_CS2106),
+                        new ModuleCode(MODULE_CODE_STR_CS2106));
         GoToCommand secondGoToCommand =
-                new GoToCommand(new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_MA2001));
+                new GoToCommand(new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_MA2001),
+                        new ModuleCode(MODULE_CODE_STR_MA2001));
 
         // same object -> returns true
         assertTrue(firstGoToCommand.equals(firstGoToCommand));
 
         // same values -> returns true
         GoToCommand firstGoToCommandCopy =
-                new GoToCommand(new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_CS2106));
+                new GoToCommand(new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_CS2106),
+                        new ModuleCode(MODULE_CODE_STR_CS2106));
         assertTrue(firstGoToCommand.equals(firstGoToCommandCopy));
 
         // different types -> returns false
@@ -55,7 +59,8 @@ public class GoToCommandParserTest {
     @Test
     public void parse_validArgs_returnsFindCommand() {
         GoToCommand expectedGoToCommand =
-                new GoToCommand(new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_CS2106));
+                new GoToCommand(new ModuleCodeMatchesKeywordPredicate(MODULE_CODE_STR_CS2106),
+                        new ModuleCode(MODULE_CODE_STR_CS2106));
 
         // no leading and trailing whitespaces
         assertParseSuccess(parser, MODULE_CODE_STR_CS2106, expectedGoToCommand);

--- a/src/test/java/seedu/address/testutil/TypicalModules.java
+++ b/src/test/java/seedu/address/testutil/TypicalModules.java
@@ -34,6 +34,8 @@ public class TypicalModules {
             .withModuleTitle(VALID_CS_MODULE_TITLE).build();
     public static final Module MA2001 = new ModuleBuilder().withModuleCode(VALID_MA_MODULE_CODE)
             .withModuleTitle(VALID_MA_MODULE_TITLE).build();
+
+    // Not inside typical modules
     public static final Module CS2103T_WITH_TASK_A =
             new ModuleBuilder().withModuleCode("CS2103T").withTasks(VALID_TASKS.subList(0, 1))
                     .withModuleTitle("Software Engineering").build();


### PR DESCRIPTION
_Disclaimer: This is a draft pull request with code written to display relevant contacts of module upon navigation (already done), but there are still things not done, namely_ 
* There currently exists no way to add a person to a module (coming soon).
* Files in the test folder have not yet been updated (done now).

Currently, the contacts and modules of Plannit are displayed side by side in the GUI, but there is no linkage between the two components.

This needs to change as
* If contacts are not linked to modules, contacts have essentially no purpose in Plannit and would act as a redundant feature that does not contribute to the streamlined value proposition of our application.
* Users may mistakenly assume that the contacts shown are linked to the modules that they are currently navigating to (as the GUI screens are side by side)

Hence, this _draft_ pull request does the following:
* Implement display contacts of module upon navigation feature

Resolves #80.