### PR TITLE
Configure build.gradle to enable assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,13 @@ dependencies {
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: jUnitVersion
 }
 
+//@@author cheeheng-reused
+//Reused from https://stackoverflow.com/questions/48396274/how-to-enable-assertions-in-the-gradle-run-task
+run {
+    enableAssertions = true
+}
+//@@author
+
 shadowJar {
     archiveFileName = 'plannit.jar'
 }


### PR DESCRIPTION
Enabling assertions in build.gradle is required, according to the grading script. This pull request aims to address that.

<img width="527" alt="image" src="https://user-images.githubusercontent.com/13196670/196225550-e1160c48-6ca3-4697-9551-f80a72e67a8e.png">
