### PR TITLE
Implement sort by module code and name in filtered list

### DIFF
--- a/src/main/java/seedu/address/model/module/Module.java
+++ b/src/main/java/seedu/address/model/module/Module.java
@@ -18,7 +18,7 @@ import seedu.address.model.person.Person;
  * Represents a Module in the address book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Module {
+public class Module implements Comparable<Module> {
 
     // Default value for empty module title
     public static final String EMPTY_MODULE_TITLE = "";
@@ -222,4 +222,8 @@ public class Module {
         return builder.toString();
     }
 
+    @Override
+    public int compareTo(Module other) {
+        return moduleCode.compareTo(other.moduleCode);
+    }
 }

--- a/src/main/java/seedu/address/model/module/ModuleCode.java
+++ b/src/main/java/seedu/address/model/module/ModuleCode.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Module's module code in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidModuleCode(String)}.
  */
-public class ModuleCode {
+public class ModuleCode implements Comparable<ModuleCode> {
     public static final String MESSAGE_CONSTRAINTS =
             "Module code should only contain alphanumeric characters, and it should not be blank";
 
@@ -61,5 +61,10 @@ public class ModuleCode {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    @Override
+    public int compareTo(ModuleCode other) {
+        return value.compareTo(other.value);
     }
 }

--- a/src/main/java/seedu/address/model/module/UniqueModuleList.java
+++ b/src/main/java/seedu/address/model/module/UniqueModuleList.java
@@ -3,6 +3,7 @@ package seedu.address.model.module;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -47,6 +48,7 @@ public class UniqueModuleList implements Iterable<Module> {
             throw new DuplicateModuleException();
         }
         internalList.add(toAdd);
+        Collections.sort(internalList);
     }
 
     /**
@@ -67,6 +69,7 @@ public class UniqueModuleList implements Iterable<Module> {
         }
 
         internalList.set(index, editedModule);
+        Collections.sort(internalList);
     }
 
     /**
@@ -104,6 +107,7 @@ public class UniqueModuleList implements Iterable<Module> {
     public void setModules(UniqueModuleList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
+        Collections.sort(internalList);
     }
 
     /**
@@ -117,6 +121,7 @@ public class UniqueModuleList implements Iterable<Module> {
         }
 
         internalList.setAll(modules);
+        Collections.sort(internalList);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Person's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}.
  */
-public class Name {
+public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
@@ -56,4 +56,8 @@ public class Name {
         return fullName.hashCode();
     }
 
+    @Override
+    public int compareTo(Name other) {
+        return fullName.compareTo(other.fullName);
+    }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -8,7 +8,7 @@ import java.util.Objects;
  * Represents a Person in the address book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Person {
+public class Person implements Comparable<Person> {
 
     private static final String VALID_PHONE_NUMBER = "91234567";
     private static final String VALID_EMAIL = "dinosaur@gmail.com";
@@ -101,4 +101,8 @@ public class Person {
         return builder.toString();
     }
 
+    @Override
+    public int compareTo(Person other) {
+        return name.compareTo(other.name);
+    }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -46,6 +47,7 @@ public class UniquePersonList implements Iterable<Person> {
             throw new DuplicatePersonException();
         }
         internalList.add(toAdd);
+        Collections.sort(internalList);
     }
 
     /**
@@ -66,6 +68,7 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.set(index, editedPerson);
+        Collections.sort(internalList);
     }
 
     /**
@@ -103,6 +106,7 @@ public class UniquePersonList implements Iterable<Person> {
     public void setPersons(UniquePersonList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
+        Collections.sort(internalList);
     }
 
     /**
@@ -116,6 +120,7 @@ public class UniquePersonList implements Iterable<Person> {
         }
 
         internalList.setAll(persons);
+        Collections.sort(internalList);
     }
 
     /**

--- a/src/test/java/seedu/address/model/module/ModuleCodeTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleCodeTest.java
@@ -30,4 +30,16 @@ public class ModuleCodeTest {
         assertFalse(isValidModuleCode(EMPTY_MODULE_CODE));
         assertFalse(isValidModuleCode(null));
     }
+
+    @Test
+    public void compareTo() {
+        ModuleCode cs2106 = new ModuleCode(VALID_CS2106_MODULE_CODE);
+        ModuleCode ma2001 = new ModuleCode(VALID_MA2001_MODULE_CODE);
+
+        assertTrue(cs2106.compareTo(ma2001) < 0); // lexicographically smaller module code against larger
+
+        assertTrue(cs2106.compareTo(cs2106) == 0); // Same module
+
+        assertTrue(ma2001.compareTo(cs2106) > 0); // lexicographically larger module code against smaller
+    }
 }

--- a/src/test/java/seedu/address/model/module/ModuleTest.java
+++ b/src/test/java/seedu/address/model/module/ModuleTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_CS2106_MODULE_C
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MA2001_MODULE_CODE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MA2001_MODULE_TITLE;
 import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalModules.CS2103T;
 import static seedu.address.testutil.TypicalModules.CS2106;
 import static seedu.address.testutil.TypicalModules.MA2001;
 
@@ -63,6 +64,15 @@ public class ModuleTest {
         String moduleWithLeadingSpaces = " " + VALID_CS2106_MODULE_CODE;
         editedCs2106 = new ModuleBuilder(CS2106).withModuleCode(moduleWithLeadingSpaces).build();
         assertTrue(CS2106.isSameModule(editedCs2106));
+    }
+
+    @Test
+    public void compareTo() {
+        assertTrue(CS2103T.compareTo(CS2106) < 0); // lexicographically smaller module against larger
+
+        assertTrue(CS2106.compareTo(CS2106) == 0); // Same module
+
+        assertTrue(MA2001.compareTo(CS2106) > 0); // lexicographically larger module against smaller
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/NameTest.java
+++ b/src/test/java/seedu/address/model/person/NameTest.java
@@ -3,6 +3,8 @@ package seedu.address.model.person;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.EMPTY_STRING;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -37,5 +39,17 @@ public class NameTest {
         assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+    }
+
+    @Test
+    public void compareTo() {
+        Name amy = new Name(VALID_NAME_AMY);
+        Name bob = new Name(VALID_NAME_BOB);
+
+        assertTrue(amy.compareTo(bob) < 0); // lexicographically smaller name against larger
+
+        assertTrue(amy.compareTo(amy) == 0); // Same person
+
+        assertTrue(bob.compareTo(amy) > 0); // lexicographically larger name against smaller
     }
 }

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -6,7 +6,9 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.CARL;
 
 import org.junit.jupiter.api.Test;
 
@@ -69,5 +71,14 @@ public class PersonTest {
         // different phone -> returns false
         editedAlice = new PersonBuilder(ALICE).withPhone(VALID_PHONE_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
+    }
+
+    @Test
+    public void compareTo() {
+        assertTrue(AMY.compareTo(BOB) < 0); // lexicographically smaller person against larger
+
+        assertTrue(AMY.compareTo(AMY) == 0); // Same person
+
+        assertTrue(CARL.compareTo(BOB) > 0); // lexicographically larger person against smaller
     }
 }


### PR DESCRIPTION
Currently, the GUI displays modules and contacts based on the order in which they are added.

This needs to be changed so as to improve UX and increase ease of use for users.

Thus, this pull request does the following:
* Implement sorting of `UniqueModuleList` by module code
* Implement sorting of `UniquePersonList` by name

Resolves #96.