### PR TITLE
Update `Task` Ui to allow resizing of display.

### DIFF
--- a/src/main/java/seedu/address/ui/ModuleCard.java
+++ b/src/main/java/seedu/address/ui/ModuleCard.java
@@ -48,14 +48,11 @@ public class ModuleCard extends UiPart<Region> {
     private Label id;
     @FXML
     private Label moduleTitle;
-    @FXML
-    private FlowPane tasks;
-    @FXML
-    private FlowPane links;
-    // Independent UI parts
     private TaskListPanel taskListPanel;
     @FXML
     private StackPane taskListPanelPlaceholder;
+    @FXML
+    private FlowPane links;
 
     /**
      * Creates a {@code ModuleCode} with the given {@code Module} and index to

--- a/src/main/java/seedu/address/ui/TaskCard.java
+++ b/src/main/java/seedu/address/ui/TaskCard.java
@@ -33,7 +33,8 @@ public class TaskCard extends UiPart<Region> {
     private Label id;
 
     /**
-     * Creates a {@code TaskCode} with the given {@code Task} and index to display.
+     * Creates a {@code TaskCard} with the given {@code Task} and index to
+     * display.
      */
     public TaskCard(Task task, int displayedIndex) {
         super(FXML);

--- a/src/main/java/seedu/address/ui/TaskListPanel.java
+++ b/src/main/java/seedu/address/ui/TaskListPanel.java
@@ -31,9 +31,10 @@ public class TaskListPanel extends UiPart<Region> {
         super(FXML);
         taskListView.setItems(taskList);
         taskListView.setCellFactory(listView -> new TaskListViewCell());
-        // 80 = Top padding + Bottom padding + Label Height = 15 + 15 + 50.
+        // 82 = Top padding + Bottom padding + Top border + Bottom border + Label Height
+        //    = 15 + 15 + 1 + 1 + 50.
         taskListView.prefHeightProperty().bind(
-                Bindings.size(taskList).multiply(80));
+                Bindings.size(taskList).multiply(82));
     }
 
     /**

--- a/src/main/java/seedu/address/ui/TaskListPanel.java
+++ b/src/main/java/seedu/address/ui/TaskListPanel.java
@@ -2,11 +2,13 @@ package seedu.address.ui;
 
 import java.util.logging.Logger;
 
+import javafx.beans.binding.Bindings;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.VBox;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.module.task.Task;
 
@@ -18,6 +20,8 @@ public class TaskListPanel extends UiPart<Region> {
     private final Logger logger = LogsCenter.getLogger(TaskListPanel.class);
 
     @FXML
+    private VBox taskListContainer;
+    @FXML
     private ListView<Task> taskListView;
 
     /**
@@ -27,6 +31,9 @@ public class TaskListPanel extends UiPart<Region> {
         super(FXML);
         taskListView.setItems(taskList);
         taskListView.setCellFactory(listView -> new TaskListViewCell());
+        // 80 = Top padding + Bottom padding + Label Height = 15 + 15 + 50.
+        taskListView.prefHeightProperty().bind(
+                Bindings.size(taskList).multiply(80));
     }
 
     /**

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -16,8 +16,8 @@
          title="Plannit" minWidth="450" minHeight="600"
          onCloseRequest="#handleExit">
   <icons>
-<!--    Image is produced by GoodWare and is available for free on Flaticon-->
-<!--    https://www.flaticon.com/authors/good-ware-->
+    <!-- Image is produced by GoodWare and is available for free on Flaticon-->
+    <!-- https://www.flaticon.com/authors/good-ware-->
     <Image url="@/images/saturn.png" />
   </icons>
   <scene>

--- a/src/main/resources/view/ModuleListCard.fxml
+++ b/src/main/resources/view/ModuleListCard.fxml
@@ -19,7 +19,7 @@
       <padding>
         <Insets top="5" right="5" bottom="5" left="5" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
+      <HBox VBox.vgrow="ALWAYS" spacing="5" alignment="CENTER_LEFT">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
@@ -30,17 +30,18 @@
         <Label fx:id="moduleTitle" text="\$moduleTitle"
                styleClass="cell_small_label" />
       </HBox>
+      <!-- HBox with tasks and links. -->
       <HBox>
-        <!--        prefWidth of 200 is half of module list's width. -->
+        <!-- prefWidth of 200 is half of module list's width. -->
         <VBox fx:id="taskList" styleClass="pane-with-border" minWidth="170"
-              prefWidth="200" HBox.hgrow="ALWAYS">
+              prefWidth="200" HBox.hgrow="ALWAYS" >
           <Label alignment="CENTER" styleClass="underlined-text"
                  maxWidth="Infinity">
             Tasks
           </Label>
           <StackPane fx:id="taskListPanelPlaceholder" />
         </VBox>
-        <!--        prefWidth of 200 is half of module list's width. -->
+        <!-- prefWidth of 200 is half of module list's width. -->
         <VBox styleClass="pane-with-border" minWidth="170"
               prefWidth="200" HBox.hgrow="ALWAYS">
           <Label alignment="CENTER" styleClass="underlined-text"

--- a/src/main/resources/view/ModuleListCard.fxml
+++ b/src/main/resources/view/ModuleListCard.fxml
@@ -34,7 +34,7 @@
         <VBox fx:id="taskList" styleClass="pane-with-border" minWidth="170"
               prefWidth="200" HBox.hgrow="ALWAYS">
           <Label alignment="CENTER" styleClass="underlined-text"
-                 prefWidth="200" maxWidth="Infinity">
+                 maxWidth="Infinity">
             Tasks
           </Label>
           <padding>
@@ -48,7 +48,7 @@
             <Insets top="0" right="0" bottom="0" left="0" />
           </padding>
           <Label alignment="CENTER" styleClass="underlined-text"
-                 prefWidth="200" maxWidth="Infinity">
+                 maxWidth="Infinity">
             Links
           </Label>
           <FlowPane fx:id="links" />

--- a/src/main/resources/view/ModuleListCard.fxml
+++ b/src/main/resources/view/ModuleListCard.fxml
@@ -31,6 +31,7 @@
                styleClass="cell_small_label" />
       </HBox>
       <HBox>
+        <!--        prefWidth of 200 is half of module list's width. -->
         <VBox fx:id="taskList" styleClass="pane-with-border" minWidth="170"
               prefWidth="200" HBox.hgrow="ALWAYS">
           <Label alignment="CENTER" styleClass="underlined-text"
@@ -42,6 +43,7 @@
           </padding>
           <StackPane fx:id="taskListPanelPlaceholder" />
         </VBox>
+        <!--        prefWidth of 200 is half of module list's width. -->
         <VBox styleClass="pane-with-border" minWidth="170"
               prefWidth="200" HBox.hgrow="ALWAYS">
           <padding>

--- a/src/main/resources/view/ModuleListCard.fxml
+++ b/src/main/resources/view/ModuleListCard.fxml
@@ -13,7 +13,7 @@
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="400" />
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>

--- a/src/main/resources/view/ModuleListCard.fxml
+++ b/src/main/resources/view/ModuleListCard.fxml
@@ -33,7 +33,7 @@
       <!-- HBox with tasks and links. -->
       <HBox>
         <!-- prefWidth of 200 is half of module list's width. -->
-        <VBox fx:id="taskList" styleClass="pane-with-border" minWidth="170"
+        <VBox styleClass="pane-with-border" minWidth="100"
               prefWidth="200" HBox.hgrow="ALWAYS" >
           <Label alignment="CENTER" styleClass="underlined-text"
                  maxWidth="Infinity">
@@ -42,7 +42,7 @@
           <StackPane fx:id="taskListPanelPlaceholder" />
         </VBox>
         <!-- prefWidth of 200 is half of module list's width. -->
-        <VBox styleClass="pane-with-border" minWidth="170"
+        <VBox styleClass="pane-with-border" minWidth="100"
               prefWidth="200" HBox.hgrow="ALWAYS">
           <Label alignment="CENTER" styleClass="underlined-text"
                  maxWidth="Infinity">

--- a/src/main/resources/view/ModuleListCard.fxml
+++ b/src/main/resources/view/ModuleListCard.fxml
@@ -38,17 +38,11 @@
                  maxWidth="Infinity">
             Tasks
           </Label>
-          <padding>
-            <Insets top="0" right="0" bottom="0" left="0" />
-          </padding>
           <StackPane fx:id="taskListPanelPlaceholder" />
         </VBox>
         <!--        prefWidth of 200 is half of module list's width. -->
         <VBox styleClass="pane-with-border" minWidth="170"
               prefWidth="200" HBox.hgrow="ALWAYS">
-          <padding>
-            <Insets top="0" right="0" bottom="0" left="0" />
-          </padding>
           <Label alignment="CENTER" styleClass="underlined-text"
                  maxWidth="Infinity">
             Links

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.VBox?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 
-<HBox id="cardPane" fx:id="cardPane"
-      xmlns="http://javafx.com/javafx/8"
-      xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <!-- prefWidth of 200 is half of module list's width. -->
@@ -17,17 +12,18 @@
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="5" />
+        <Insets bottom="15" left="15" right="15" top="15" />
       </padding>
-      <HBox>
+      <HBox minHeight="50">
         <!-- Task number. Min width necessary to prevent truncation. -->
-        <Label fx:id="id" styleClass="cell_small_label" HBox.hgrow="ALWAYS"
-               minWidth="15"/>
+        <Label fx:id="id" alignment="TOP_LEFT"  contentDisplay="TOP" maxHeight="Infinity"
+               minWidth="15" styleClass="cell_small_label" HBox.hgrow="ALWAYS" />
         <!-- Task Description. -->
-        <Label fx:id="taskDescription"
-               styleClass="cell_small_label" textAlignment="JUSTIFY"
-               text="\$task" wrapText="true"/>
+        <Label fx:id="taskDescription" alignment="TOP_LEFT" contentDisplay="TOP" maxHeight="Infinity" styleClass="cell_small_label" text="\$task" textAlignment="JUSTIFY" wrapText="true" />
       </HBox>
     </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -12,7 +12,7 @@
       xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
-<!--      prefWidth of 200 is half of module list's width. -->
+      <!--      prefWidth of 200 is half of module list's width. -->
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="200" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" GridPane.columnIndex="0">
@@ -20,10 +20,10 @@
         <Insets top="5" right="5" bottom="5" left="5" />
       </padding>
       <HBox>
-<!--        Task number. Min width necessary to prevent truncation. -->
+        <!--        Task number. Min width necessary to prevent truncation. -->
         <Label fx:id="id" styleClass="cell_small_label" HBox.hgrow="ALWAYS"
                minWidth="15"/>
-<!--        Task Description. -->
+        <!--        Task Description. -->
         <Label fx:id="taskDescription"
                styleClass="cell_small_label" textAlignment="JUSTIFY"
                text="\$task" wrapText="true"/>

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -12,7 +12,7 @@
       xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
-      <!--      prefWidth of 200 is half of module list's width. -->
+      <!-- prefWidth of 200 is half of module list's width. -->
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="200" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" GridPane.columnIndex="0">
@@ -20,10 +20,10 @@
         <Insets top="5" right="5" bottom="5" left="5" />
       </padding>
       <HBox>
-        <!--        Task number. Min width necessary to prevent truncation. -->
+        <!-- Task number. Min width necessary to prevent truncation. -->
         <Label fx:id="id" styleClass="cell_small_label" HBox.hgrow="ALWAYS"
                minWidth="15"/>
-        <!--        Task Description. -->
+        <!-- Task Description. -->
         <Label fx:id="taskDescription"
                styleClass="cell_small_label" textAlignment="JUSTIFY"
                text="\$task" wrapText="true"/>

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -3,26 +3,25 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.FlowPane?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
 <HBox id="cardPane" fx:id="cardPane"
       xmlns="http://javafx.com/javafx/8"
       xmlns:fx="http://javafx.com/fxml/1">
-  <GridPane maxWidth="Infinity">
+  <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
-      <ColumnConstraints minWidth="10"/>
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="200" />
     </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="40" GridPane.columnIndex="0">
+    <VBox alignment="CENTER_LEFT" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="5" />
       </padding>
       <HBox>
-        <Label fx:id="id" styleClass="cell_small_label" HBox.hgrow="NEVER"/>
-        <Label fx:id="taskDescription" prefWidth="180" maxWidth="Infinity"
+        <Label fx:id="id" styleClass="cell_small_label" HBox.hgrow="ALWAYS"
+               minWidth="15"/>
+        <Label fx:id="taskDescription"
                styleClass="cell_small_label" textAlignment="JUSTIFY"
                text="\$task" wrapText="true"/>
       </HBox>

--- a/src/main/resources/view/TaskListCard.fxml
+++ b/src/main/resources/view/TaskListCard.fxml
@@ -12,6 +12,7 @@
       xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
+<!--      prefWidth of 200 is half of module list's width. -->
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="200" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" GridPane.columnIndex="0">
@@ -19,8 +20,10 @@
         <Insets top="5" right="5" bottom="5" left="5" />
       </padding>
       <HBox>
+<!--        Task number. Min width necessary to prevent truncation. -->
         <Label fx:id="id" styleClass="cell_small_label" HBox.hgrow="ALWAYS"
                minWidth="15"/>
+<!--        Task Description. -->
         <Label fx:id="taskDescription"
                styleClass="cell_small_label" textAlignment="JUSTIFY"
                text="\$task" wrapText="true"/>

--- a/src/main/resources/view/TaskListPanel.fxml
+++ b/src/main/resources/view/TaskListPanel.fxml
@@ -3,7 +3,6 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox >
-  <ListView fx:id="taskListView" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-            prefWidth="180" prefHeight="200"/>
+<VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+  <ListView fx:id="taskListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/main/resources/view/TaskListPanel.fxml
+++ b/src/main/resources/view/TaskListPanel.fxml
@@ -3,6 +3,7 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<VBox fx:id="taskListContainer" xmlns="http://javafx.com/javafx/8"
+      xmlns:fx="http://javafx.com/fxml/1">
   <ListView fx:id="taskListView" VBox.vgrow="ALWAYS" />
 </VBox>


### PR DESCRIPTION
* The current implementation of `TaskCard` in the Ui of Plannit is fixed at 200px. With this PR, the `TaskCard` grows and shrinks relatively to the window size.

| Narrow window size | Wide window size |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/83915879/198078516-02d32eea-ca35-45c8-9407-b82b746eb3ec.png) | ![image](https://user-images.githubusercontent.com/83915879/198078436-71858c9d-230b-47bb-9bff-d4a929f8e726.png)|

* The size of the entire task list panel was hard coded earlier. With this PR, the size of the task list panel will be relative to the number of tasks, with each task's `TaskCard` being allocated 82px. 
<img src="https://user-images.githubusercontent.com/83915879/198077259-e957e2a0-7593-4461-a6e8-26c69d3c566e.png" width="500"/>

* Should a task require more space, the `TaskCard` will grow accordingly, and scrolling will be enabled in the task list panel.

<img src = "https://user-images.githubusercontent.com/83915879/198077770-ddb72069-d06f-4320-931a-7d7b523e6837.png"  width="500"/>

Notice how vertical scrolling is now enabled, and task 4's height is larger than the others