### PR TITLE
Fix bug in updating module card

### DIFF
--- a/src/main/java/seedu/address/logic/commands/HomeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HomeCommand.java
@@ -18,8 +18,8 @@ public class HomeCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        updateFilteredList(model);
         model.setHomeStatus(true);
+        updateFilteredList(model);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 


### PR DESCRIPTION
### Discovered a funny bug in the `home` command that occurs with our UI:
 1. Currently, we update the filtered module list first before setting the `isHome` status to `true`:
```java
      @Override
          public CommandResult execute(Model model) {
              requireNonNull(model);
              updateFilteredList(model);        <--- update modules
              model.setHomeStatus(true);        <--- update home status
              return new CommandResult(MESSAGE_SUCCESS);
          }
```
 2. As a result, the updated modules in the filtered module list are not updated with the latest `isHome` information and do not know they are `home` yet:
<img src="https://user-images.githubusercontent.com/83915879/198331321-f3e6c355-4475-4e9c-9d5f-000ca00c5200.png" width="500"/>

 3. Modules still display the "_You have not added tasks to..._" message that should not be shown on the home page

### Fix: Update home status before updating filtered module list
Took so long to figure out the root of the problem, but thankfully it has a simple fix 😅 