### PR TITLE
Fix swap task indexing bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SwapTaskNumbersCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SwapTaskNumbersCommand.java
@@ -84,7 +84,7 @@ public class SwapTaskNumbersCommand extends Command {
                                          List<Index> taskIndexesToSwap) throws CommandException {
         int numberOfTasksInTaskList = moduleToSwapTaskNumbers.getTasks().size();
         for (Index taskIndex : taskIndexesToSwap) {
-            if (taskIndex.getZeroBased() > numberOfTasksInTaskList) {
+            if (taskIndex.getOneBased() > numberOfTasksInTaskList) {
                 throw new CommandException(MESSAGE_NO_SUCH_TASK_NUMBER);
             }
         }

--- a/src/test/java/seedu/address/logic/commands/SwapTaskNumbersCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SwapTaskNumbersCommandTest.java
@@ -85,12 +85,12 @@ public class SwapTaskNumbersCommandTest {
     @Test
     public void execute_nonExistentTaskNumber_throwsCommandException() {
         Index validTaskNumber = Index.fromOneBased(1);
-        Index nonExistentTaskNumberNinetyNine = Index.fromOneBased(99);
+        Index nonExistentTaskNumberFour = Index.fromOneBased(4);
         Index nonExistentTaskNumberHundred = Index.fromOneBased(100);
         // one valid task number
         SwapTaskNumbersDescriptor descriptorWithOneValidTaskNumber =
                 new SwapTaskNumbersDescriptorBuilder(CS2106_WITH_TYPICAL_TASKS,
-                        validTaskNumber, nonExistentTaskNumberNinetyNine).build();
+                        validTaskNumber, nonExistentTaskNumberFour).build();
         SwapTaskNumbersCommand swapTaskCommandWithOneValidTaskNumber =
                 new SwapTaskNumbersCommand(descriptorWithOneValidTaskNumber);
         assertThrows(CommandException.class,
@@ -100,7 +100,7 @@ public class SwapTaskNumbersCommandTest {
         // no valid task numbers
         SwapTaskNumbersDescriptor descriptorWithNoValidTaskNumber =
                 new SwapTaskNumbersDescriptorBuilder(CS2106_WITH_TYPICAL_TASKS,
-                        nonExistentTaskNumberHundred, nonExistentTaskNumberNinetyNine).build();
+                        nonExistentTaskNumberHundred, nonExistentTaskNumberFour).build();
         SwapTaskNumbersCommand swapTaskCommandWithNoValidTaskNumber =
                 new SwapTaskNumbersCommand(descriptorWithNoValidTaskNumber);
         assertThrows(CommandException.class,


### PR DESCRIPTION
## `indexOutOfBoundsException` bug has been fixed in this PR
### Reason why bug occurred:
When validating the numbers, the `Index::getZeroBased()` was compared against the `numberOfTasksToSwap` (which is a one based). Hence, swapping task 4 in a list of 3 task will not be picked up as an error by the `swapTaskNumbersCommand`.

### Reason why tests did not pick it up:
Boundary value analysis was not adopted in the test cases. In the test case, there were 3 tasks in the module but the indexes tested was index 99 and 100. 😭 

### Modications:
* We validate the numbers by comparing `Index::getOneBased()` against `numberOfTasksToSwap` instead.
* Test now uses index 4 (boundary value)