### PR TITLE
Fix missing task description bug

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedTask.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedTask.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.module.task.Task;
@@ -25,6 +26,11 @@ class JsonAdaptedTask {
      */
     public JsonAdaptedTask(Task source) {
         taskDescription = source.getTaskDescription();
+    }
+
+    @JsonValue
+    public String getTaskDescription() {
+        return taskDescription;
     }
 
     /**


### PR DESCRIPTION
`getTaskDescription()` removal has been the cause of the bug reported in #165. This pull request aims to restore `getTaskDescription()` removal.

Lesson learnt: IntelliJ code analysis of unused code is not always 100% reliable.