### PR TITLE
Fix truncation of long names issue #181

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -12,7 +12,7 @@
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
+      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="90" GridPane.columnIndex="0">
       <padding>


### PR DESCRIPTION
This PR addresses issue #181 by removing the `prefWidth` attribute of the element containing each person. Long names and emails will now create a horizontal scroll bar in the persons list instead of being truncated:
![image](https://user-images.githubusercontent.com/83915879/199441499-2a41511e-954b-413d-a2a8-d5ca90af4ba3.png)
