### PR TITLE
Fix invalid command format error messages

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLinkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLinkCommand.java
@@ -26,7 +26,7 @@ import seedu.address.model.person.Person;
 public class AddLinkCommand extends Command {
 
     public static final String COMMAND_WORD = "add-link";
-    public static final String MESSAGE_USAGE = "[" + COMMAND_WORD + "]: Add link(s) to a the module "
+    public static final String MESSAGE_USAGE = "[" + COMMAND_WORD + "]: Add link(s) to a module "
             + "using its module code, link URL, and a user-defined alias.\n"
             + "A 'm/' flag should be appended to the front the module code;\n"
             + "a 'l/' flag should be appended to the front of each link URL;\n"

--- a/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddModuleCommand.java
@@ -15,7 +15,7 @@ public class AddModuleCommand extends Command {
 
     public static final String COMMAND_WORD = "add-module";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to Plannit."
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a module to Plannit.\n"
             + "Parameters: "
             + PREFIX_MODULE_CODE + "MODULE_CODE "
             + "[" + PREFIX_MODULE_TITLE + "MODULE_TITLE]\n"

--- a/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonCommand.java
@@ -16,7 +16,7 @@ public class AddPersonCommand extends Command {
 
     public static final String COMMAND_WORD = "add-person";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to Plannit. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to Plannit.\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_EMAIL + "EMAIL "

--- a/src/main/java/seedu/address/logic/commands/AddPersonToModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPersonToModuleCommand.java
@@ -31,7 +31,7 @@ public class AddPersonToModuleCommand extends Command {
     public static final String COMMAND_WORD = "add-person-to-module";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person (identified by name)"
-            + "to a module (identified by module code).\n"
+            + " to a module (identified by module code).\n"
             + "Parameters: "
             + PREFIX_MODULE_CODE + "MODULE_CODE "
             + PREFIX_NAME + "NAME \n"

--- a/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonCommand.java
@@ -20,7 +20,7 @@ public class DeletePersonCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by his name used in the displayed person list.\n"
             + "Parameters: "
-            + PREFIX_NAME + "NAME "
+            + PREFIX_NAME + "NAME\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe ";
 

--- a/src/main/java/seedu/address/logic/commands/DeletePersonFromModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePersonFromModuleCommand.java
@@ -31,7 +31,7 @@ public class DeletePersonFromModuleCommand extends Command {
     public static final String COMMAND_WORD = "delete-person-from-module";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a person (identified by name)"
-            + "belonging in a module (identified by module code).\n"
+            + " belonging in a module (identified by module code).\n"
             + "Parameters: "
             + PREFIX_MODULE_CODE + "MODULE_CODE "
             + PREFIX_NAME + "NAME \n"

--- a/src/main/java/seedu/address/logic/commands/EditModuleCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditModuleCommand.java
@@ -27,8 +27,8 @@ public class EditModuleCommand extends Command {
             + "by the index number used in the displayed module list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_MODULE_CODE + "MODULE_CODE] "
-            + "[" + PREFIX_MODULE_TITLE + "MODULE_TITLE]\n"
+            + "([" + PREFIX_MODULE_CODE + "MODULE_CODE] "
+            + "[" + PREFIX_MODULE_TITLE + "MODULE_TITLE])\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_MODULE_CODE + "CS1231S";
 

--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -29,9 +29,9 @@ public class EditPersonCommand extends Command {
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_NAME + "NAME] "
+            + "([" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
-            + "[" + PREFIX_PHONE + "PHONE]\n"
+            + "[" + PREFIX_PHONE + "PHONE])\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_EMAIL + "johndoe@example.com "
             + PREFIX_PHONE + "91234567 ";


### PR DESCRIPTION
Fixes the following bugs:
- Inconsistent formatting of error messages, in particular, missing '\n' before "Parameters:" for `add-module` (see #125) and `add-person` missing '\n' before "Example:" for `delete-person`
- Missing round brackets (to indicate at least one parameter has to be present) for `edit-person` and `edit-module`
- Fix grammatical error in message for `add-link` command
- Missing spaces between two words in `add-person-to-module` and `delete-person-from-module`

Resolves #125 